### PR TITLE
feat: Home에서 협찬사 이미지를 외부 링크와 함께 슬라이더에 추가

### DIFF
--- a/src/components/ImgSlider/index.module.css
+++ b/src/components/ImgSlider/index.module.css
@@ -17,3 +17,7 @@
 .rightArrow {
     right: 6px;
 }
+
+.layout a > img {
+    width: 100%;
+}

--- a/src/components/ImgSlider/index.tsx
+++ b/src/components/ImgSlider/index.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef } from "react";
 import styles from "./index.module.css";
 
 interface Props {
-    images: { src: string; description: string }[];
+    images: { src: string; description: string; externalLink?: string }[];
     currentIndex: number;
     onChange: (idx: number) => void;
 }
@@ -34,9 +34,27 @@ const ImgSlider = ({ images, currentIndex, onChange }: Props) => {
     return (
         <div className={styles.layout}>
             <Slider ref={sliderRef} {...settings}>
-                {images.map((image, index) => (
-                    <img key={index} src={image.src} alt={image.description} />
-                ))}
+                {images.map((image, index) =>
+                    image.externalLink ? (
+                        <a
+                            key={index}
+                            href={image.externalLink}
+                            target="_blank"
+                        >
+                            <img
+                                key={index}
+                                src={image.src}
+                                alt={image.description}
+                            />
+                        </a>
+                    ) : (
+                        <img
+                            key={index}
+                            src={image.src}
+                            alt={image.description}
+                        />
+                    )
+                )}
             </Slider>
             {currentIndex !== 0 && (
                 <button

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -37,7 +37,41 @@ const Home = () => {
                             "/playground_main.png",
                         description: "로고 1",
                     },
-                    // { src: "logo.svg", description: "로고 2" },
+                    {
+                        src:
+                            import.meta.env.VITE_STORAGE_HOSTNAME +
+                            "/spon/%EA%B5%BF%EB%A7%88%EB%8D%94%EC%8B%A0%EB%93%9C%EB%A1%AC.jpg",
+                        description: "협찬사 1 굿마더신드롬",
+                        externalLink: "https://goodmothersyndrome.com/",
+                    },
+                    {
+                        src:
+                            import.meta.env.VITE_STORAGE_HOSTNAME +
+                            "/spon/%EB%B9%84%ED%83%80%EC%B9%B4%ED%8E%98.jpg",
+                        description: "협찬사 2 비타카페",
+                        externalLink: "https://www.vitacafe.co.kr/",
+                    },
+                    {
+                        src:
+                            import.meta.env.VITE_STORAGE_HOSTNAME +
+                            "/spon/%EC%98%A4%EC%9D%B4%EB%AE%A4.jpg",
+                        description: "협찬사 3 오이뮤",
+                        externalLink: "https://oimu-seoul.com/",
+                    },
+                    {
+                        src:
+                            import.meta.env.VITE_STORAGE_HOSTNAME +
+                            "/spon/%EC%9C%A0%ED%94%BD.jpg",
+                        description: "협찬사 4 유픽",
+                        externalLink: "https://www.youpick.kr/",
+                    },
+                    {
+                        src:
+                            import.meta.env.VITE_STORAGE_HOSTNAME +
+                            "/spon/%EC%A1%B4%EC%8A%A4%EB%B8%94%EB%A0%8C%EB%93%9C.jpg",
+                        description: "협찬사 5 존스블렌드",
+                        externalLink: "https://johns-blend.kr/",
+                    },
                 ]}
                 currentIndex={postIdx}
                 onChange={(number) => setPostIdx(number)}


### PR DESCRIPTION
협찬사 5개 이미지를 감싼 외부 링크(a 태그, _blank)를 슬라이더에 추가.
기존 슬라이더는 img 단일 태그만 허용했으므로 prop을 구체화하여 외부 링크를 입력한 슬라이더 요소에 한해서 링크 연결